### PR TITLE
getIndexName() only doesn't lowercase package names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+out

--- a/grails-app/domain/test/upperCase/UpperCase.groovy
+++ b/grails-app/domain/test/upperCase/UpperCase.groovy
@@ -1,0 +1,5 @@
+package test.upperCase
+
+class UpperCase {
+    def name;
+}

--- a/src/java/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.java
+++ b/src/java/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.java
@@ -80,9 +80,9 @@ public class SearchableClassMapping {
         String name = domainClass.getPackageName();
         if (name == null || name.length() == 0) {
             // index name must be lowercase (org.elasticsearch.indices.InvalidIndexNameException)
-            name = domainClass.getPropertyName().toLowerCase();
+            name = domainClass.getPropertyName();
         }
-        return name;
+        return name.toLowerCase();
     }
 
     /**

--- a/test/unit/org/grails/plugins/elasticsearch/mapping/SearchableClassMappingTest.groovy
+++ b/test/unit/org/grails/plugins/elasticsearch/mapping/SearchableClassMappingTest.groovy
@@ -1,0 +1,25 @@
+package org.grails.plugins.elasticsearch.mapping;
+
+
+import org.junit.Test
+import org.codehaus.groovy.grails.commons.GrailsDomainClass
+import org.codehaus.groovy.grails.commons.DefaultGrailsDomainClass
+import test.Photo
+import test.upperCase.UpperCase
+
+public class SearchableClassMappingTest {
+    @Test
+    public void testGetIndexName() throws Exception {
+        GrailsDomainClass dc = new DefaultGrailsDomainClass(Photo.class);
+        SearchableClassMapping mapping = new SearchableClassMapping(dc,null);
+        assert "test" == mapping.getIndexName();
+    }
+
+    @Test
+    public void testIndexNameIsLowercaseWhenPackageNameIsLowercase() throws Exception {
+        GrailsDomainClass dc = new DefaultGrailsDomainClass(UpperCase.class);
+        SearchableClassMapping mapping = new SearchableClassMapping(dc,null);
+        String indexName = mapping.getIndexName();
+        assert "test.uppercase" == indexName;
+    }
+}


### PR DESCRIPTION
If you have a packagename such as test.upperCase, getIndexName() on SearchableClassMapping will return 'test.upperCase', which will then blow up in elastic search.  I modified it to lowercase everything.  Unit tests are also included.  Feel free to ignore .gitignore, it was just easier to ignore idea files, and I can't figure out how to get github to do a pull request on just one commit.
