### PR TITLE
This is an upgrade to ES 0.16.2

### DIFF
--- a/ElasticsearchGrailsPlugin.groovy
+++ b/ElasticsearchGrailsPlugin.groovy
@@ -36,7 +36,7 @@ class ElasticsearchGrailsPlugin {
     static LOG = Logger.getLogger("org.grails.plugins.elasticsearch.ElasticsearchGrailsPlugin")
 
     // the plugin version
-    def version = "0.16.1.1-SNAPSHOT"
+    def version = "0.16.2.1-SNAPSHOT"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.6 > *"
     // the other plugins this plugin depends on

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -29,8 +29,8 @@ grails.project.dependency.resolution = {
     }
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
-        runtime 'org.elasticsearch:elasticsearch:0.16.1'
-        runtime 'org.elasticsearch:elasticsearch-lang-groovy:0.16.1'
+        runtime 'org.elasticsearch:elasticsearch:0.16.2'
+        runtime 'org.elasticsearch:elasticsearch-lang-groovy:0.16.2'
     }
     plugins {
         build ":release:1.0.0.M2"


### PR DESCRIPTION
It is to be noticed that whenever I run a grails test-app, tests fail, but that's already the case without the patch.
