### PR TITLE
A selection of minor changes, including coping with larger data sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 *.iml
 out
+target
+plugin.xml

--- a/src/groovy/org/grails/plugins/elasticsearch/util/DomainDynamicMethodsUtils.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/util/DomainDynamicMethodsUtils.groovy
@@ -45,24 +45,36 @@ class DomainDynamicMethodsUtils {
                 // Only inject the methods if the domain is mapped as "root"
                 if (elasticSearchContextHolder.getMappingContext(domainCopy)?.root) {
                     // Inject the search method
-                    domain.metaClass.'static'.search << { String q, Map params = [indices: domainCopy.packageName ?: domainCopy.propertyName, types: domainCopy.clazz] ->
+                    domain.metaClass.'static'.search << { String q, Map params = [:] ->
+                        params.indices = domainCopy.packageName ?: domainCopy.propertyName
+                        params.types = domainCopy.clazz
                         elasticSearchService.search(q, params)
                     }
-                    domain.metaClass.'static'.search << { Map params = [indices: domainCopy.packageName ?: domainCopy.propertyName, types: domainCopy.clazz], Closure q ->
+                    domain.metaClass.'static'.search << { Map params = [:], Closure q ->
+                        params.indices = domainCopy.packageName ?: domainCopy.propertyName
+                        params.types = domainCopy.clazz
                         elasticSearchService.search(params, q)
                     }
-                    domain.metaClass.'static'.search << { Closure q, Map params = [indices: domainCopy.packageName ?: domainCopy.propertyName, types: domainCopy.clazz] ->
+                    domain.metaClass.'static'.search << { Closure q, Map params = [:] ->
+                        params.indices = domainCopy.packageName ?: domainCopy.propertyName
+                        params.types = domainCopy.clazz
                         elasticSearchService.search(params, q)
                     }
 
                     // Inject the countHits method
-                    domain.metaClass.'static'.countHits << { String q, Map params = [indices: domainCopy.packageName ?: domainCopy.propertyName, types: domainCopy.clazz] ->
+                    domain.metaClass.'static'.countHits << { String q, Map params = [:] ->
+                        params.indices = domainCopy.packageName ?: domainCopy.propertyName
+                        params.types = domainCopy.clazz
                         elasticSearchService.countHits(q, params)
                     }
-                    domain.metaClass.'static'.countHits << { Map params = [indices: domainCopy.packageName ?: domainCopy.propertyName, types: domainCopy.clazz], Closure q ->
+                    domain.metaClass.'static'.countHits << { Map params = [:], Closure q ->
+                        params.indices = domainCopy.packageName ?: domainCopy.propertyName
+                        params.types = domainCopy.clazz
                         elasticSearchService.countHits(params, q)
                     }
-                    domain.metaClass.'static'.countHits << { Closure q, Map params = [indices: domainCopy.packageName ?: domainCopy.propertyName, types: domainCopy.clazz] ->
+                    domain.metaClass.'static'.countHits << { Closure q, Map params = [:] ->
+                        params.indices = domainCopy.packageName ?: domainCopy.propertyName
+                        params.types = domainCopy.clazz
                         elasticSearchService.countHits(params, q)
                     }
 

--- a/src/java/org/grails/plugins/elasticsearch/mapping/SearchableClassMappingConfigurator.java
+++ b/src/java/org/grails/plugins/elasticsearch/mapping/SearchableClassMappingConfigurator.java
@@ -95,6 +95,11 @@ public class SearchableClassMappingConfigurator {
                         installedIndices.add(scm.getIndexName());
                         LOG.debug(elasticMapping.toString());
 
+                        // Wait for the index to be ready
+                        elasticSearchClient.admin().cluster().prepareHealth(scm.getIndexName())
+                                .setWaitForYellowStatus()
+                                .execute().actionGet();
+
                         // If the index already exists, ignore the exception
                     } catch (IndexAlreadyExistsException iaee) {
                         LOG.debug("Index " + scm.getIndexName() + " already exists, skip index creation.");


### PR DESCRIPTION
Hi,

These commits cover several little problems I found and fixed, including adding support for a cluster.name config option and allowing mass-index operations to survive for larger data sets (eg 50,000+ rows on a 20 field table).

Simon
