### PR TITLE
Return Hit Scores on Request

### DIFF
--- a/grails-app/services/org/grails/plugins/elasticsearch/ElasticSearchService.groovy
+++ b/grails-app/services/org/grails/plugins/elasticsearch/ElasticSearchService.groovy
@@ -428,6 +428,18 @@ public class ElasticSearchService implements GrailsApplicationAware {
                 result.highlight = highlightResults
             }
 
+            LOG.debug "Adding score information to results."
+
+            //Extract score information
+            //Records a map from hits of (hit.id, hit.score) returned in 'scores'
+            if (params.score) {
+                def scoreResults = [:]
+                for (SearchHit hit: searchHits) {
+                    scoreResults[(hit.id)] = hit.score
+                }
+                result.scores = scoreResults
+            }
+
             return result
         }
     }


### PR DESCRIPTION
I'm using the plugin on a current project and I had the need to return scoring after performing queries with custom boost + scoring.  I found it handy to have the param available and wanted to push it back for inclusion.

Thanks

DK
