### PR TITLE
Updated Maven repository url

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -27,7 +27,7 @@ grails.project.dependency.resolution = {
         //mavenRepo "http://repository.codehaus.org"
         //mavenRepo "http://download.java.net/maven/2/"
         //mavenRepo "http://repository.jboss.com/maven2/"
-        mavenRepo "http://oss.sonatype.org/content/groups/staging/"
+        mavenRepo "http://oss.sonatype.org/content/repositories/releases/"
     }
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.


### PR DESCRIPTION
0.17.7 has been removed from http://oss.sonatype.org/content/groups/staging/ and now exists at http://oss.sonatype.org/content/repositories/releases/
