### PR TITLE
Bump från grails 2.0.3 to grails 2.0.4

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,9 +1,9 @@
 #Grails Metadata file
-#Tue Apr 17 00:20:27 CEST 2012
-app.grails.version=2.0.3
+#Mon May 28 09:03:01 CEST 2012
+app.grails.version=2.0.4
 app.name=elasticsearch
 app.servlet.version=2.4
 app.version=0.1
-plugins.hibernate=2.0.3
+plugins.hibernate=2.0.4
 plugins.svn=1.0.2
-plugins.tomcat=2.0.3
+plugins.tomcat=2.0.4


### PR DESCRIPTION
Use the newly released grails 2.0.4 rather than 2.0.3
