### PR TITLE
Inject the grails-application rather than using ApplicationHolder

### DIFF
--- a/ElasticsearchGrailsPlugin.groovy
+++ b/ElasticsearchGrailsPlugin.groovy
@@ -117,7 +117,9 @@ class ElasticsearchGrailsPlugin {
             elasticSearchClient = ref("elasticSearchClient")
             grailsApplication = ref("grailsApplication")
         }
-        customEditorRegistrar(CustomEditorRegistar)
+        customEditorRegistrar(CustomEditorRegistar) {
+            grailsApplication = ref("grailsApplication")
+        }
         jsonDomainFactory(JSONDomainFactory) {
             elasticSearchContextHolder = ref("elasticSearchContextHolder")
             grailsApplication = ref("grailsApplication")

--- a/src/groovy/org/grails/plugins/elasticsearch/conversion/CustomEditorRegistar.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/conversion/CustomEditorRegistar.groovy
@@ -7,9 +7,10 @@ import org.codehaus.groovy.grails.commons.ApplicationHolder
 
 class CustomEditorRegistar implements PropertyEditorRegistrar {
   def elasticSearchContextHolder
+  def grailsApplication
 
   void registerCustomEditors(PropertyEditorRegistry reg) {
-    elasticSearchContextHolder = ApplicationHolder.application.mainContext.getBean('elasticSearchContextHolder')
+    elasticSearchContextHolder = grailsApplication.mainContext.getBean('elasticSearchContextHolder')
     reg.registerCustomEditor(Date.class, new JSONDateBinder(elasticSearchContextHolder.config.date.formats as List))
   }
 


### PR DESCRIPTION
Prevent a

[DEPRECATED] Method ApplicationHolder.getApplication() is deprecated and will be removed in a future version of Grails

when searching the index.
