### PR TITLE
maintenance plugin cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data
 target
 prodDb.properties
 prodDb.script
+.link_to_grails_plugins

--- a/application.properties
+++ b/application.properties
@@ -2,8 +2,3 @@
 #Tue Apr 17 00:20:27 CEST 2012
 app.grails.version=2.0.3
 app.name=elasticsearch
-app.servlet.version=2.4
-app.version=0.1
-plugins.hibernate=2.0.3
-plugins.svn=1.0.2
-plugins.tomcat=2.0.3

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -34,7 +34,8 @@ grails.project.dependency.resolution = {
         runtime "org.elasticsearch:elasticsearch-lang-groovy:1.1.0"
     }
     plugins {
-        build (":release:latest.integration") {
+		runtime ":hibernate:$grailsVersion"
+        build (":release:latest.integration", ":rest-client-builder:latest.integration") {
             export = false
         }
         test (":spock:0.6") {


### PR DESCRIPTION
-added rest-client-builder explicitly to the plugin-dependencies in
BuildConfig to be able to use export = false
    - current version of release-plugin has a dependency to
rest-client-builder which is pulled into the app if not excluded
explicitly with export=false (earlier versions of the release-plugin did
the same but with the svn plugin, which it does not depend on any longer
since the plugin-repo moved from codehaus-svn -> an artifactory maven
server)
-added hibernate:grailsVersion as dependency to BuildConfig.groovy
    -plugin (still) depends on hibernate
-cleaned application.properties
    -i guess it got polluted by some "grails upgrade" call
-extended .gitignore for STS
