### PR TITLE
Add gateway.type configuration support

### DIFF
--- a/src/docs/guide/2. Configuration.gdoc
+++ b/src/docs/guide/2. Configuration.gdoc
@@ -62,6 +62,11 @@ niofs | Stores the shard index on the file system (maps to Lucene NIOFSDirectory
 simplefs | Stores using a plain forward implementation of file system storage (maps to Lucene SimpleFsDirectory) using random access file.
 {table}
 
+* @elasticSearch.gateway.type@
+Determine the gateway type to be used.
+More details on the possible values are in the [ElasticSearch Documentation|http://www.elasticsearch.org/guide/reference/modules/gateway/].
+Using a setting of "none" (possibly in combination with index.store.type set to "memory") can be useful for tests.
+
 * @elasticSearch.maxBulkRequest@
 Max number of requests to process at once.
 Reduce this value if you have memory issue when indexing a big amount of data at once.

--- a/src/groovy/org/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
@@ -83,6 +83,13 @@ class ClientNodeFactoryBean implements FactoryBean {
                 } else {
                     LOG.debug "Local ElasticSearch client with default store type configured."
                 }
+                def gatewayType = elasticSearchContextHolder.config.gateway.type
+                if (gatewayType) {
+                    nb.settings().put('gateway.type', gatewayType as String)
+                    LOG.debug "Local ElasticSearch client with gateway type of ${gatewayType} configured."
+                } else {
+                    LOG.debug "Local ElasticSearch client with default gateway type configured."
+                }
                 def queryParsers = elasticSearchContextHolder.config.index.queryparser
                 if (queryParsers) {
                     queryParsers.each { type, clz ->


### PR DESCRIPTION
This patch adds support for the elasticsearch config option: gateway.type

I found I needed this to set this to "none" to avoid repeat startup problems when using "grails test-app" in my application.
