### PR TITLE
Enable searching by referenced domain object IDs

### DIFF
--- a/src/java/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.java
+++ b/src/java/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.java
@@ -99,7 +99,7 @@ public class ElasticSearchMappingFactory {
                         props = new LinkedHashMap<String, Object>();
                         propOptions.put("properties", props);
                     }
-                    props.put("id", defaultDescriptor("long", "no", true));
+                    props.put("id", defaultDescriptor("long", "not_analyzed", true));
                     props.put("class", defaultDescriptor("string", "no", true));
                     props.put("ref", defaultDescriptor("string", "no", true));
                 }


### PR DESCRIPTION
I had the need to include referenced object IDs in my search criteria which I couldn't do.  This patch enables such searches.
