### PR TITLE
result scoring

### DIFF
--- a/grails-app/services/org/grails/plugins/elasticsearch/ElasticSearchService.groovy
+++ b/grails-app/services/org/grails/plugins/elasticsearch/ElasticSearchService.groovy
@@ -450,7 +450,10 @@ public class ElasticSearchService implements GrailsApplicationAware {
             if (params.score) {
                 def scoreResults = [:]
                 for (SearchHit hit: searchHits) {
-                    scoreResults[(hit.id)] = hit.score
+                    if ( scoreResults[ hit.index + "." + hit.type ] == null ) {
+                        scoreResults[ hit.index + "." + hit.type ] = [:]
+                    }
+                    scoreResults[ hit.index + "." + hit.type ][ hit.id ] = hit.score
                 }
                 result.scores = scoreResults
             }


### PR DESCRIPTION
The search results currently include an option collection of result scores. The result scores are however identified only by id, which could cause clashes when different types of domain object (an perhaps results from different indices) are returned. The current patch will identify the objects by index and object type (which should closely mimic your package + classname) which should prevent the id clashes from happening.

Hope this helps a few people out there,

Roger
