### PR TITLE
Fix for #15: Problem in Hibernate sessions management

### DIFF
--- a/ElasticsearchGrailsPlugin.groovy
+++ b/ElasticsearchGrailsPlugin.groovy
@@ -36,7 +36,7 @@ class ElasticsearchGrailsPlugin {
     static LOG = Logger.getLogger("org.grails.plugins.elasticsearch.ElasticsearchGrailsPlugin")
 
     // the plugin version
-    def version = "0.19.3-SNAPSHOT"
+    def version = "0.19.4-SNAPSHOT"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.0 > *"
     // the other plugins this plugin depends on

--- a/ElasticsearchGrailsPlugin.groovy
+++ b/ElasticsearchGrailsPlugin.groovy
@@ -36,7 +36,7 @@ class ElasticsearchGrailsPlugin {
     static LOG = Logger.getLogger("org.grails.plugins.elasticsearch.ElasticsearchGrailsPlugin")
 
     // the plugin version
-    def version = "0.19.8-SNAPSHOT"
+    def version = "0.19.10-SNAPSHOT"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.0 > *"
     // the other plugins this plugin depends on

--- a/application.properties
+++ b/application.properties
@@ -1,9 +1,10 @@
 #Grails Metadata file
-#Tue Apr 17 00:20:27 CEST 2012
-app.grails.version=2.0.3
+#Tue May 29 17:13:55 CEST 2012
+app.grails.version=2.0.4
 app.name=elasticsearch
 app.servlet.version=2.4
 app.version=0.1
-plugins.hibernate=2.0.3
+plugins.hibernate=2.0.4
+plugins.rest-client-builder=1.0.2
 plugins.svn=1.0.2
-plugins.tomcat=2.0.3
+plugins.tomcat=2.0.4

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Tue Apr 17 00:20:27 CEST 2012
-app.grails.version=2.0.4
+#Tue Oct 16 16:05:41 CEST 2012
+app.grails.version=2.1.1
 app.name=elasticsearch

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
 #Tue Apr 17 00:20:27 CEST 2012
-app.grails.version=2.0.3
+app.grails.version=2.0.4
 app.name=elasticsearch

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -30,7 +30,7 @@ grails.project.dependency.resolution = {
     }
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
-        runtime "org.elasticsearch:elasticsearch:0.19.3"
+        runtime "org.elasticsearch:elasticsearch:0.19.4"
         runtime "org.elasticsearch:elasticsearch-lang-groovy:1.1.0"
     }
     plugins {

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -30,7 +30,7 @@ grails.project.dependency.resolution = {
     }
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
-        runtime "org.elasticsearch:elasticsearch:0.19.8"
+        runtime "org.elasticsearch:elasticsearch:0.19.10"
         runtime "org.elasticsearch:elasticsearch-lang-groovy:1.1.0"
     }
     plugins {

--- a/src/groovy/org/grails/plugins/elasticsearch/AuditEventListener.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/AuditEventListener.groovy
@@ -175,7 +175,7 @@ class AuditEventListener extends SaveOrUpdateEventListener implements PostCollec
 
     void onFlush(FlushEvent flushEvent) {
         // When a flush occurs, execute the pending requests in the buffer (the buffer is cleared automatically)
-        indexRequestQueue.executeRequests()
+        indexRequestQueue.executeRequests(flushEvent.session)
     }
 
     void setApplicationContext(ApplicationContext applicationContext) {
@@ -230,6 +230,7 @@ class AuditEventListener extends SaveOrUpdateEventListener implements PostCollec
             def objsToDelete = deletedObjects.get()
             switch (status) {
                 case STATUS_COMMITTED:
+                    LOG.debug "Committing ${objsToIndex ? objsToIndex.size() : 0} objs."
                     if (objsToIndex && objsToDelete) {
                         objsToIndex.keySet().removeAll(objsToDelete.keySet())
                     }

--- a/src/java/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.java
+++ b/src/java/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.java
@@ -16,7 +16,6 @@
 package org.grails.plugins.elasticsearch.mapping;
 
 import org.codehaus.groovy.grails.commons.GrailsClassUtils;
-import org.grails.plugins.elasticsearch.ElasticSearchContextHolder;
 import org.springframework.util.ClassUtils;
 
 import java.util.*;


### PR DESCRIPTION
This should fix #15 for persistent entities updated in a Hibernate session. When Hibernate flushes the session, the AuditEventListener.onFlush() is invoked. The existing session can be used instead of creating a new one. Also, in this use case I don't see any reason why it's necessary to use a HibernatePersistenceContextInterceptor.

I've also modified the use of the interceptor for batch index requests, as it appears that they are not always being initialized/destroyed correctly.
