### PR TITLE
Elastic type names are not distinct for same name domain classes in different packages

### DIFF
--- a/src/java/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.java
+++ b/src/java/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.java
@@ -53,7 +53,8 @@ public class DomainClassUnmarshaller {
         DefaultUnmarshallingContext unmarshallingContext = new DefaultUnmarshallingContext();
         List results = new ArrayList();
         for(SearchHit hit : hits) {
-            String domainClassName = hit.index().equals(hit.type()) ? DefaultGroovyMethods.capitalize(hit.index()) : (hit.index() + '.' + DefaultGroovyMethods.capitalize(hit.type()));
+            String type = hit.type();
+            String domainClassName = hit.index().equals(type) ? DefaultGroovyMethods.capitalize(hit.index()) : (hit.index() + '.' + DefaultGroovyMethods.capitalize(type.substring(type.lastIndexOf(".") + 1)));
             SearchableClassMapping scm = elasticSearchContextHolder.getMappingContext(domainClassName);
             if (scm == null) {
                 LOG.warn("Unknown SearchHit: " + hit.id() + "#" + hit.type() + ", domain class name: " + domainClassName);

--- a/src/java/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.java
+++ b/src/java/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.java
@@ -89,7 +89,7 @@ public class SearchableClassMapping {
      * @return type name for ES mapping.
      */
     public String getElasticTypeName() {
-        return GrailsNameUtils.getPropertyName(domainClass.getClazz());
+        return domainClass.getFullName().toLowerCase();
     }
 
     public boolean isAll() {


### PR DESCRIPTION
In ran into this issue while using a local checkout of the plugin. My app has a `my.package.User` and `my.package.Tag` domain class just as the plugin has. When I persist instances of my users, bulk index items are never removed from the operation batch list, because `test.User` is assumed to be the domain class' type, effectively resulting in an endless loop, as items are pushed again and again.

Mapping the domain class to the Elastic type name only takes the simple class name into account. `my.package.User` and `test.User` are both mapped to `user`.

This pull request is fixing this by using the fully-qualified class name, e.g. `my.package.user` and `test.user`.
