### PR TITLE
Configurable index name

### DIFF
--- a/src/groovy/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.groovy
@@ -16,12 +16,8 @@
 
 package org.grails.plugins.elasticsearch.mapping;
 
-import org.apache.commons.lang.StringUtils;
 import org.codehaus.groovy.grails.commons.GrailsDomainClass;
 import org.grails.plugins.elasticsearch.ElasticSearchContextHolder;
-
-import java.util.Collection;
-import java.util.Map;
 
 public class SearchableClassMapping {
     
@@ -78,8 +74,7 @@ public class SearchableClassMapping {
      * @return ElasticSearch index name
      */
     public String getIndexName() {
-        String name = ((Map<String, Map<String, String>>) domainClass.getGrailsApplication().getConfig().get("elasticSearch")).get("index").get("name");
-        if (StringUtils.isEmpty(name)) name = domainClass.getPackageName();
+        String name = domainClass.grailsApplication.config.elasticSearch.index.name ?: domainClass.packageName
         if (name == null || name.length() == 0) {
             // index name must be lowercase (org.elasticsearch.indices.InvalidIndexNameException)
             name = domainClass.getPropertyName();

--- a/src/java/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.java
+++ b/src/java/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.java
@@ -16,11 +16,12 @@
 
 package org.grails.plugins.elasticsearch.mapping;
 
-import grails.util.GrailsNameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.codehaus.groovy.grails.commons.GrailsDomainClass;
 import org.grails.plugins.elasticsearch.ElasticSearchContextHolder;
 
 import java.util.Collection;
+import java.util.Map;
 
 public class SearchableClassMapping {
     
@@ -77,7 +78,8 @@ public class SearchableClassMapping {
      * @return ElasticSearch index name
      */
     public String getIndexName() {
-        String name = domainClass.getPackageName();
+        String name = ((Map<String, Map<String, String>>) domainClass.getGrailsApplication().getConfig().get("elasticSearch")).get("index").get("name");
+        if (StringUtils.isEmpty(name)) name = domainClass.getPackageName();
         if (name == null || name.length() == 0) {
             // index name must be lowercase (org.elasticsearch.indices.InvalidIndexNameException)
             name = domainClass.getPropertyName();

--- a/test/unit/org/grails/plugins/elasticsearch/mapping/SearchableClassMappingTest.groovy
+++ b/test/unit/org/grails/plugins/elasticsearch/mapping/SearchableClassMappingTest.groovy
@@ -1,5 +1,6 @@
 package org.grails.plugins.elasticsearch.mapping;
 
+import grails.test.mixin.*
 
 import org.junit.Test
 import org.codehaus.groovy.grails.commons.GrailsDomainClass
@@ -7,19 +8,38 @@ import org.codehaus.groovy.grails.commons.DefaultGrailsDomainClass
 import test.Photo
 import test.upperCase.UpperCase
 
+@Mock([Photo, UpperCase])
 public class SearchableClassMappingTest {
+
     @Test
     public void testGetIndexName() throws Exception {
         GrailsDomainClass dc = new DefaultGrailsDomainClass(Photo.class);
+        dc.grailsApplication = grailsApplication
         SearchableClassMapping mapping = new SearchableClassMapping(dc,null);
         assert "test" == mapping.getIndexName();
     }
 
     @Test
+    public void testManuallyConfiguredIndexName() throws Exception {
+        GrailsDomainClass dc = new DefaultGrailsDomainClass(Photo.class);
+        dc.grailsApplication = grailsApplication
+        config.elasticSearch.index.name = "index-name"
+        SearchableClassMapping mapping = new SearchableClassMapping(dc,null);
+        assert "index-name" == mapping.getIndexName();
+    }
+
+    @Test
     public void testIndexNameIsLowercaseWhenPackageNameIsLowercase() throws Exception {
         GrailsDomainClass dc = new DefaultGrailsDomainClass(UpperCase.class);
+        dc.grailsApplication = grailsApplication
         SearchableClassMapping mapping = new SearchableClassMapping(dc,null);
         String indexName = mapping.getIndexName();
         assert "test.uppercase" == indexName;
     }
+    
+    @After
+    void cleanup() {
+        config.elasticSearch.index.name = null
+    }
+
 }


### PR DESCRIPTION
With this patch it is possible to specify index name in Config.groovy:

elasticSearch.index.name = "index-name"

This is useful if you want to share elasticsearch server with several instances of your application (e.g. for testing/staging environments)
