### PR TITLE
Deactivate unmarshalling of components via config

### DIFF
--- a/grails-app/conf/DefaultElasticSearch.groovy
+++ b/grails-app/conf/DefaultElasticSearch.groovy
@@ -50,6 +50,11 @@ elasticSearch {
    *  at once. If this setting is not specified, 500 will be use by default.
    */
   maxBulkRequest = 500
+  
+  /**
+   * Should component-mapped properties be unmarshalled. The default is true.
+   */
+  unmarshallComponents = true
 }
 
 environments {

--- a/src/java/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.java
+++ b/src/java/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.java
@@ -177,7 +177,7 @@ public class DomainClassUnmarshaller {
                 return unmarshallReference(refDomainClass, data, unmarshallingContext);
             }
 
-            if (data.containsKey("class")) {
+            if (data.containsKey("class") && (Boolean)grailsApplication.getFlatConfig().get("elasticSearch.unmarshallComponents")) {
                 // Embedded instance.
                 if (!scpm.isComponent()) {
                     // maybe ignore?


### PR DESCRIPTION
#42 shows that unmarshalling components is potentially slow. These changes allow deactivation of component unmarshalling via configuration.

I don't need the components restored when working with search results and I get performance improvements by factor 10-20 in my project. So maybe this is also of interest to others.
