### PR TITLE
Multiple enhancements to support more flexibility in configuration

### DIFF
--- a/grails-app/services/org/grails/plugins/elasticsearch/ElasticSearchService.groovy
+++ b/grails-app/services/org/grails/plugins/elasticsearch/ElasticSearchService.groovy
@@ -231,11 +231,11 @@ public class ElasticSearchService implements GrailsApplicationAware {
                     LOG.debug("Deleting all instances of ${scm.domainClass}")
                 }
 
-                // The index is splitted to avoid out of memory exception
-                def count = scm.domainClass.clazz.count() ?: 0
-                int nbRun = Math.ceil(count / maxRes)
-
                 scm.domainClass.clazz.withNewSession {session ->
+                    // The index is splitted to avoid out of memory exception
+                    def count = scm.domainClass.clazz.count() ?: 0
+                    int nbRun = Math.ceil(count / maxRes)
+
                     for(int i = 0; i < nbRun; i++) {
                         scm.domainClass.clazz.withCriteria {
                             firstResult(i * maxRes)

--- a/src/groovy/org/grails/plugins/elasticsearch/conversion/marshall/DeepDomainClassMarshaller.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/conversion/marshall/DeepDomainClassMarshaller.groovy
@@ -15,7 +15,7 @@ class DeepDomainClassMarshaller extends DefaultMarshaller {
     if (!scm) {
         throw new IllegalStateException("Domain class ${domainClass} is not searchable.")
     }
-    for (GrailsDomainClassProperty prop in domainClass.persistantProperties) {
+    for (GrailsDomainClassProperty prop in domainClass.properties) {
       def propertyMapping = scm.getPropertyMapping(prop.name)
       if (!propertyMapping) {
         continue

--- a/src/groovy/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/mapping/SearchableClassMapping.groovy
@@ -29,9 +29,14 @@ public class SearchableClassMapping {
     private boolean root = true;
     private boolean all = true;
 
+    /** Identifier properties used for indexing */
+    private List<String> identityProperties;
+    private String identitySeparator = ':';
+
     public SearchableClassMapping(GrailsDomainClass domainClass, Collection<SearchableClassPropertyMapping> propertiesMapping) {
         this.domainClass = domainClass;
         this.propertiesMapping = propertiesMapping;
+        this.identityProperties = [domainClass.identifier.name];
     }
 
     public SearchableClassPropertyMapping getPropertyMapping(String propertyName) {
@@ -57,6 +62,22 @@ public class SearchableClassMapping {
 
     public GrailsDomainClass getDomainClass() {
         return domainClass;
+    }
+
+    public List<String> getIdentityProperties() {
+        return identityProperties;
+    }
+
+    public void setIdentityProperties(List<String> propertyNames) {
+        this.identityProperties = propertyNames;
+    }
+
+    public String getIdentitySeparator() {
+        return identitySeparator;
+    }
+
+    public void setIdentitySeparator(String separator) {
+        this.identitySeparator = separator;
     }
 
     /**

--- a/src/java/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.java
+++ b/src/java/org/grails/plugins/elasticsearch/conversion/unmarshall/DomainClassUnmarshaller.java
@@ -59,12 +59,20 @@ public class DomainClassUnmarshaller {
                 LOG.warn("Unknown SearchHit: " + hit.id() + "#" + hit.type() + ", domain class name: ");
                 continue;
             }
-            String domainClassName = scm.getDomainClass().getFullName();
 
-            GrailsDomainClassProperty identifier = scm.getDomainClass().getIdentifier();
-            Object id = typeConverter.convertIfNecessary(hit.id(), identifier.getType());
             GroovyObject instance = (GroovyObject) scm.getDomainClass().newInstance();
-            instance.setProperty(identifier.getName(), id);
+
+            // The id stored in the index may be a composition of multiple fields.  Decompose it and seat each of the
+            // values contained there in (excluding non-persistant properties as they're likely transient or read-only)
+            String[] idValues = hit.id().split(scm.getIdentitySeparator());
+            for (int i = 0; i < idValues.length; i++) {
+                String propertyName = scm.getIdentityProperties().get(i);
+                GrailsDomainClassProperty property = scm.getDomainClass().getPropertyByName(propertyName);
+                if (property.isPersistent()) {
+                    Object value = typeConverter.convertIfNecessary(idValues[i], property.getType());
+                    instance.setProperty(property.getName(), value);
+                }
+            }
 
             /*def mapContext = elasticSearchContextHolder.getMappingContext(domainClass.propertyName)?.propertiesMapping*/
             Map rebuiltProperties = new HashMap();


### PR DESCRIPTION
This change set address a few issues, which were implemented by us specifically to support the ability to have indexes that support multi-tenant databases.  Specifically, we did the following:
- When using "only" in the mapping, transient properties will now be allowed
- "indexId" may now be added to mapping which will allow a change to which field is used as _id in the index.
- Additionally, "indexId" will support multiple fields
- Corrected a problem where counting the instances of a domain class sometimes occurred using the wrong hibernate session
